### PR TITLE
Rw simplify

### DIFF
--- a/minivhd.c
+++ b/minivhd.c
@@ -98,6 +98,7 @@ time_t vhd_get_created_time(VHDMeta *vhdm)
 int vhd_file_is_vhd(FILE *f)
 {
         uint8_t buffer[VHD_FOOTER_SZ];
+        memset(buffer, 0, sizeof buffer);
         fseeko64(f, -VHD_FOOTER_SZ, SEEK_END);
         fread(buffer, 1, VHD_FOOTER_SZ, f);
         int valid_vhd = 0;

--- a/minivhd.c
+++ b/minivhd.c
@@ -532,7 +532,17 @@ int vhd_write_sectors(VHDMeta *vhdm, FILE *f, int offset, int nr_sectors, void *
                         /* We need to create a data block if it does not yet exist. */
                         if (vhdm->sparse_bat_arr[curr_blk] == VHD_SPARSE_BLK)
                         {
-                                vhd_create_blk(vhdm, f, curr_blk);
+                                /* If the sector to write contains all zeros, hold off on block creation and therefore
+                                   writing to file for this sector. */
+                                if (memcmp(buff_ptr, VHD_ZERO_SECTOR, VHD_SECTOR_SZ) == 0)
+                                {
+                                        buff_ptr += VHD_SECTOR_SZ;
+                                        continue;
+                                }
+                                else
+                                {
+                                        vhd_create_blk(vhdm, f, curr_blk);
+                                }
                         }
                         if (curr_blk != prev_blk)
                         {

--- a/minivhd.c
+++ b/minivhd.c
@@ -612,7 +612,7 @@ int vhd_format_sectors(VHDMeta *vhdm, FILE *f, int offset, int nr_sectors)
         else
         {
                 /* Code from PCem */
-                off64_t addr;
+                uint64_t addr;
                 int c;
                 uint8_t zero_buffer[VHD_SECTOR_SZ];
                 memset(zero_buffer, 0, VHD_SECTOR_SZ);

--- a/minivhd.c
+++ b/minivhd.c
@@ -588,12 +588,8 @@ int vhd_format_sectors(VHDMeta *vhdm, FILE *f, int offset, int nr_sectors)
         }
         else
         {
-                /* Code from PCem */
-                uint64_t addr;
                 int c;
-                uint8_t zero_buffer[VHD_SECTOR_SZ];
-                memset(zero_buffer, 0, VHD_SECTOR_SZ);
-                addr = (uint64_t)offset * VHD_SECTOR_SZ;
+                uint64_t addr = (uint64_t)offset * VHD_SECTOR_SZ;
                 fseeko64(f, addr, SEEK_SET);
                 for (c = 0; c < transfer_sectors; c++)
                 {

--- a/minivhd.c
+++ b/minivhd.c
@@ -469,7 +469,6 @@ int vhd_read_sectors(VHDMeta *vhdm, FILE *f, int offset, int nr_sectors, void *b
                 for (s = offset; s <= ls; s++)
                 {
                         curr_blk = s / vhdm->sparse_spb;
-                        sib = s % vhdm->sparse_spb;
                         /* If the data block doesn't yet exist, fill the buffer with zero data */
                         if (vhdm->sparse_bat_arr[curr_blk] == VHD_SPARSE_BLK)
                         {
@@ -479,6 +478,7 @@ int vhd_read_sectors(VHDMeta *vhdm, FILE *f, int offset, int nr_sectors, void *b
                         {
                                 if (curr_blk != prev_blk)
                                 {
+                                        sib = s % vhdm->sparse_spb;
                                         uint32_t file_sect_offs = vhdm->sparse_bat_arr[curr_blk] + sbsz + sib;
                                         fseeko64(f, (uint64_t)file_sect_offs * VHD_SECTOR_SZ, SEEK_SET);
                                         prev_blk = curr_blk;


### PR DESCRIPTION
Removes the original "fast path" for read/write operations.

The original sector-by-sector "slow" path was reworked to make it not slow, by minimizing calls to fseek, and therefore minimizing buffer flushes between consecutive reads or writes.