### PR TITLE
Fix bug in vhd_read_sectors().

### DIFF
--- a/minivhd.c
+++ b/minivhd.c
@@ -235,6 +235,10 @@ VHDError vhd_read_file(FILE *f, VHDMeta *vhdm, const char *path)
                 {
                         /* Don't want a pointer to who knows where... */
                         vhdm->sparse_bat_arr = NULL;
+                        vhdm->sparse_bitmap_arr = NULL;
+						      vhdm->parent.f = NULL;
+						      vhdm->parent.meta = NULL;
+                   
                         vhd_raw_foot_to_meta(vhdm);
                         if (vhdm->type == VHD_DYNAMIC || vhdm->type == VHD_DIFF)
                         {
@@ -289,6 +293,11 @@ void vhd_create_file(FILE *f, VHDMeta *vhdm, int cyl, int heads, int spt, VHDTyp
         vhdm->sparse_bat_offset = VHD_FOOTER_SZ + VHD_SPARSE_HEAD_SZ;
         vhdm->sparse_block_sz = VHD_DEF_BLOCK_SZ;
         vhdm->sparse_max_bat = vhdm->curr_size / vhdm->sparse_block_sz;
+        vhdm->sparse_bat_arr = NULL;
+		  vhdm->sparse_bitmap_arr = NULL;
+		  vhdm->parent.f = NULL;
+		  vhdm->parent.meta = NULL;
+   
         if (vhdm->curr_size % vhdm->sparse_block_sz != 0)
         {
                 vhdm->sparse_max_bat += 1;
@@ -619,7 +628,7 @@ int vhd_read_sectors(VHDMeta *vhdm, FILE *f, int offset, int nr_sectors, void *b
                         {
                                 uint64_t addr = (uint64_t)s * VHD_SECTOR_SZ;
                                 fseeko64(curr_f, addr, SEEK_SET);
-                                fread(buffer, VHD_SECTOR_SZ, 1, curr_f);
+                                fread(buff_ptr, VHD_SECTOR_SZ, 1, curr_f);
                         }
                         else
                         {

--- a/minivhd.c
+++ b/minivhd.c
@@ -236,8 +236,8 @@ VHDError vhd_read_file(FILE *f, VHDMeta *vhdm, const char *path)
                         /* Don't want a pointer to who knows where... */
                         vhdm->sparse_bat_arr = NULL;
                         vhdm->sparse_bitmap_arr = NULL;
-						      vhdm->parent.f = NULL;
-						      vhdm->parent.meta = NULL;
+			vhdm->parent.f = NULL;
+			vhdm->parent.meta = NULL;
                    
                         vhd_raw_foot_to_meta(vhdm);
                         if (vhdm->type == VHD_DYNAMIC || vhdm->type == VHD_DIFF)
@@ -294,9 +294,9 @@ void vhd_create_file(FILE *f, VHDMeta *vhdm, int cyl, int heads, int spt, VHDTyp
         vhdm->sparse_block_sz = VHD_DEF_BLOCK_SZ;
         vhdm->sparse_max_bat = vhdm->curr_size / vhdm->sparse_block_sz;
         vhdm->sparse_bat_arr = NULL;
-		  vhdm->sparse_bitmap_arr = NULL;
-		  vhdm->parent.f = NULL;
-		  vhdm->parent.meta = NULL;
+	vhdm->sparse_bitmap_arr = NULL;
+	vhdm->parent.f = NULL;
+	vhdm->parent.meta = NULL;
    
         if (vhdm->curr_size % vhdm->sparse_block_sz != 0)
         {


### PR DESCRIPTION
`vhd_read_sectors()` was using the wrong buffer pointer. After fixing it, reading/writing `VHD_DIFF` images seem to work in my limited testing. (I only tested `VHD_DIFF`s with `VHD_FIXED` parents).

I also initialized some more uninitialized pointers in `vhd_read_file()` and `vhd_create_file()`.