### PR TITLE
Fix bug in multi-sector writes for sparse VHDs.

### DIFF
--- a/src/minivhd_io.c
+++ b/src/minivhd_io.c
@@ -242,6 +242,10 @@ int mvhd_sparse_diff_write(MVHDMeta* vhdm, uint32_t offset, int num_sectors, voi
     for (s = offset; s < ls; s++) {
         blk = s / vhdm->sect_per_block;
         sib = s % vhdm->sect_per_block;
+        if (vhdm->bitmap.curr_block != blk && prev_blk >= 0) {            
+            /* Write the sector bitmap for the previous block, before we replace it. */
+            mvhd_write_curr_sect_bitmap(vhdm);
+        }
         if (vhdm->block_offset[blk] == MVHD_SPARSE_BLK) {
             /* "read" the sector bitmap first, before creating a new block, as the bitmap will be
                zero either way */
@@ -249,11 +253,7 @@ int mvhd_sparse_diff_write(MVHDMeta* vhdm, uint32_t offset, int num_sectors, voi
             mvhd_create_block(vhdm, blk);
         } 
         if (blk != prev_blk) {
-            if (vhdm->bitmap.curr_block != blk) {
-                if (prev_blk >= 0) {
-                    /* Write the sector bitmap for the previous block, before we replace it. */
-                    mvhd_write_curr_sect_bitmap(vhdm);
-                }
+            if (vhdm->bitmap.curr_block != blk) {                
                 mvhd_read_sect_bitmap(vhdm, blk);
                 mvhd_fseeko64(vhdm->f, (uint64_t)sib * MVHD_SECTOR_SIZE, SEEK_CUR);
             } else {


### PR DESCRIPTION
The issue was that we first checked if the block was sparse, and if so, called `mvhd_read_sect_bitmap` followed by `mvhd_create_block`. Then later on, we checked if `vhdm->bitmap.curr_block != blk` and only called `mvhd_write_curr_sect_bitmap` if the condition was true. But the previous call to `mvhd_read_sect_bitmap` already changed `vhdm->bitmap.curr_block` So for multi-sector writes that cross block boundaries, and in which blocks after the first block were sparse, the previous sector bitmap was not getting written to disk. 